### PR TITLE
Fix dropping socket connections on a busy server

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -16,6 +16,7 @@ package main
 //   go install golang.org/x/perf/cmd/benchstat@latest
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -53,8 +54,11 @@ func benchmarkDataReader(b *testing.B, numConns int) {
 		os.Remove(sockPath)
 	})
 
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+
 	dataCh := make(chan []byte, numConns*4)
-	go DataReader(ln, dataCh)
+	go DataReader(ctx, ln, dataCh)
 
 	b.SetBytes(int64(numConns) * int64(len(benchPayload)))
 	b.ResetTimer()

--- a/core_test.go
+++ b/core_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"strings"
 	"testing"
@@ -57,8 +58,11 @@ func TestDataReaderConcurrentConnections(t *testing.T) {
 	}
 	defer ln.Close()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	dataCh := make(chan []byte, 10)
-	go DataReader(ln, dataCh)
+	go DataReader(ctx, ln, dataCh)
 
 	payload := `[{"name":"dr_counter","method":"inc"}]`
 	conns := 3
@@ -94,8 +98,11 @@ func TestHandleConnPayloadLimit(t *testing.T) {
 	}
 	defer ln.Close()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	dataCh := make(chan []byte, 2)
-	go DataReader(ln, dataCh)
+	go DataReader(ctx, ln, dataCh)
 
 	// Send a payload that exceeds maxPayloadSize — dataCh should NOT receive it.
 	c, err := net.Dial("tcp", ln.Addr().String())
@@ -155,7 +162,7 @@ func TestDataProcessorHandlesMetric(t *testing.T) {
 	doneCh <- true
 }
 
-func TestDataReaderConnectionLimit(t *testing.T) {
+func TestDataReaderBlocksWhenLimitReached(t *testing.T) {
 	SetTestLogger()
 
 	const limit = 2
@@ -166,11 +173,14 @@ func TestDataReaderConnectionLimit(t *testing.T) {
 	}
 	defer ln.Close()
 
-	dataCh := make(chan []byte, limit+1)
-	go dataReaderWithLimit(ln, dataCh, limit)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	// Open `limit` connections and keep them open (no EOF) so they hold semaphore
-	// slots inside handleConn for the duration of the test.
+	dataCh := make(chan []byte, limit+1)
+	go dataReaderWithLimit(ctx, ln, dataCh, limit)
+
+	// Hold `limit` connections open (no EOF) so they occupy semaphore slots
+	// inside handleConn for the duration of the test.
 	holders := make([]net.Conn, limit)
 	for i := range holders {
 		c, err := net.Dial("tcp", ln.Addr().String())
@@ -188,17 +198,53 @@ func TestDataReaderConnectionLimit(t *testing.T) {
 	// Give handleConn goroutines time to start and acquire their semaphore slots.
 	time.Sleep(20 * time.Millisecond)
 
-	// This connection should be immediately closed by the server (limit reached).
+	// The next connection should NOT be closed by the server. It should sit
+	// queued, waiting for a slot. We expect a Read deadline timeout, not EOF.
 	extra, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer extra.Close()
 
-	extra.SetDeadline(time.Now().Add(time.Second))
+	extra.SetDeadline(time.Now().Add(200 * time.Millisecond))
 	buf := make([]byte, 1)
 	_, readErr := extra.Read(buf)
 	if readErr == nil {
-		t.Fatal("expected server to close the connection when limit is reached, but Read succeeded")
+		t.Fatal("expected Read to time out (connection waiting for slot), but it succeeded")
+	}
+	netErr, ok := readErr.(net.Error)
+	if !ok || !netErr.Timeout() {
+		t.Fatalf("expected timeout error indicating server is waiting (not closing); got %v", readErr)
+	}
+}
+
+func TestDataReaderShutsDownOnContextCancel(t *testing.T) {
+	SetTestLogger()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Do not defer ln.Close(); DataReader's ctx watcher will close it.
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dataCh := make(chan []byte, 1)
+	done := make(chan struct{})
+	go func() {
+		DataReader(ctx, ln, dataCh)
+		close(done)
+	}()
+
+	// Let the accept loop start.
+	time.Sleep(20 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+		// expected: DataReader returned without logging an ERROR
+	case <-time.After(time.Second):
+		t.Fatal("DataReader did not exit within 1s of context cancellation")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -33,6 +35,7 @@ var (
 	pathFlag         = flag.String("path", "/metrics", "Path to use for exposing prometheus metrics")
 	logFlag          = flag.String("log", "", "Path to log file, will write to STDOUT if empty")
 	metricPrefixFlag = flag.String("metric-prefix", "", "Prefix to prepend to metric names (e.g. \"myapp\" or \"myapp_\"); a trailing \"_\" is added automatically if omitted")
+	maxConnsFlag     = flag.Int("max-connections", 512, "Maximum concurrent in-flight client connections; additional clients block until a slot frees")
 	versionFlag      = flag.Bool("v", false, "Print version information and exit")
 )
 
@@ -42,6 +45,7 @@ func init() {
 		connectionsTotal,
 		connectionsActive,
 		connectionsDroppedTotal,
+		connectionWaitSeconds,
 		bytesReceivedTotal,
 		batchSizeMetrics,
 		registeredMetrics,
@@ -84,17 +88,41 @@ func main() {
 		fmt.Fprintf(os.Stderr, "invalid -socket-mode %q: value must be in octal range 0000–7777\n", *socketModeFlag)
 		os.Exit(1)
 	}
+	if *maxConnsFlag <= 0 {
+		fmt.Fprintf(os.Stderr, "invalid -max-connections %d: must be > 0\n", *maxConnsFlag)
+		os.Exit(1)
+	}
 
 	ln, err := net.Listen("unix", *socketFlag)
 	if err != nil {
 		logger.Fatal(err)
 	}
-	defer ln.Close()
 
 	if err := os.Chmod(*socketFlag, os.FileMode(socketMode)); err != nil {
 		logger.Fatal(err)
 	}
 	logger.Printf("Socket ready: %s (mode %04o)", *socketFlag, socketMode)
+
+	// ctx drives DataReader shutdown. Cancelling it closes the listener and
+	// causes the accept loop to exit cleanly without spinning on an Accept
+	// error. readerDone is closed once DataReader returns.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	readerDone := make(chan struct{})
+
+	// shutdown signals DataReader to stop, waits briefly for it to drain, then
+	// exits with the given code. Used by every path that previously called
+	// os.Exit directly while holding the listener open.
+	shutdown := func(code int) {
+		cancel()
+		select {
+		case <-readerDone:
+		case <-time.After(time.Second):
+			logger.Println("DataReader did not exit within 1s; forcing exit")
+		}
+		os.Exit(code)
+	}
 
 	// listen for signals which make us quit
 	sigc := make(chan os.Signal, 1)
@@ -102,8 +130,7 @@ func main() {
 	go func() {
 		<-sigc
 		logger.Println("Goodbye!")
-		ln.Close()
-		os.Exit(0)
+		shutdown(0)
 	}()
 
 	// listen for USR1 signal which makes us reload our metrics definitions
@@ -123,8 +150,7 @@ func main() {
 		defer func() {
 			if r := recover(); r != nil {
 				logger.Printf("Recovered panic: %s", r)
-				ln.Close()
-				os.Exit(1)
+				shutdown(1)
 			}
 		}()
 		// this for loop must always either continue, or exit the process;
@@ -171,8 +197,7 @@ func main() {
 			logger.Println("Re-opening logs...")
 			if err := SetLogger(*logFlag); err != nil {
 				fmt.Println(err)
-				ln.Close()
-				os.Exit(1)
+				shutdown(1)
 			}
 		}
 	}()
@@ -182,7 +207,10 @@ func main() {
 		go DataParser(dataCh, metricCh)
 	}
 
-	go DataReader(ln, dataCh)
+	go func() {
+		defer close(readerDone)
+		dataReaderWithLimit(ctx, ln, dataCh, *maxConnsFlag)
+	}()
 
 	promHandler := promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
 		ErrorLog: logger,

--- a/prom_multi_proc.go
+++ b/prom_multi_proc.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -18,7 +18,7 @@ import (
 const (
 	maxPayloadSize     = 1 << 20 // 1 MiB per connection
 	readTimeout        = 5 * time.Second
-	maxConcurrentConns = 64
+	maxConcurrentConns = 512
 )
 
 var (
@@ -47,7 +47,15 @@ var (
 	connectionsDroppedTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "pmp_connections_dropped_total",
-			Help: "Connections dropped because the concurrent connection limit was reached.",
+			Help: "Connections dropped while waiting for a slot because the process is shutting down.",
+		},
+	)
+
+	connectionWaitSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "pmp_connection_wait_seconds",
+			Help:    "Time spent waiting for a free in-flight connection slot before handling. A nonzero distribution here indicates saturation of -max-connections.",
+			Buckets: []float64{0.0001, 0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
 		},
 	)
 
@@ -169,18 +177,30 @@ func ReadSpecs(r io.Reader) ([]*MetricSpec, error) {
 	return result, nil
 }
 
-func DataReader(ln net.Listener, dataCh chan<- []byte) {
-	dataReaderWithLimit(ln, dataCh, maxConcurrentConns)
+func DataReader(ctx context.Context, ln net.Listener, dataCh chan<- []byte) {
+	dataReaderWithLimit(ctx, ln, dataCh, maxConcurrentConns)
 }
 
-func dataReaderWithLimit(ln net.Listener, dataCh chan<- []byte, limit int) {
+func dataReaderWithLimit(ctx context.Context, ln net.Listener, dataCh chan<- []byte, limit int) {
+	if limit <= 0 {
+		limit = maxConcurrentConns
+	}
 	sem := make(chan struct{}, limit)
+
+	// When the context is cancelled, close the listener so the blocked Accept call
+	// returns immediately. This is the only path that should ever close ln, which
+	// makes the shutdown signal unambiguous: ctx.Err() != nil means "we did this".
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
 	logger.Println("Starting listening on socket")
 	for {
 		c, err := ln.Accept()
 		if err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				logger.Println("DataReader: listener closed")
+			if ctx.Err() != nil {
+				logger.Println("DataReader: shutting down")
 				return
 			}
 			CountMetric("error")
@@ -188,8 +208,15 @@ func dataReaderWithLimit(ln net.Listener, dataCh chan<- []byte, limit int) {
 			continue
 		}
 		connectionsTotal.Inc()
+
+		// Block until a slot is free. This restores the backpressure the old
+		// serial reader got from the OS socket backlog: clients see brief
+		// connect()/read() latency under burst instead of silent EOF, and the
+		// 5s per-connection read deadline still bounds how long a slot is held.
+		waitStart := time.Now()
 		select {
 		case sem <- struct{}{}:
+			connectionWaitSeconds.Observe(time.Since(waitStart).Seconds())
 			connectionsActive.Inc()
 			go func() {
 				defer func() {
@@ -198,11 +225,11 @@ func dataReaderWithLimit(ln net.Listener, dataCh chan<- []byte, limit int) {
 				}()
 				handleConn(c, dataCh)
 			}()
-		default:
+		case <-ctx.Done():
 			connectionsDroppedTotal.Inc()
-			CountMetric("error")
-			logger.Printf("ERROR (DataReader): connection limit %d reached, dropping connection", limit)
 			c.Close()
+			logger.Println("DataReader: shutting down")
+			return
 		}
 	}
 }


### PR DESCRIPTION
On a busy server, we can drop socket connections. Introduce a semaphore and expose a `max-connections` flag that defaults at 512.